### PR TITLE
Stop running example commands if one fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ddev restart && \
 ddev composer install
 
 # See included commands
-ddev drupal list && \
+ddev drupal list
 
 # Install drupal
 ddev drupal install && \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ddev config --auto && \
 ddev start && \
 ddev get justafish/ddev-drupal-core-dev && \
 ddev restart && \
-ddev composer install && \
+ddev composer install
 
 # See included commands
 ddev drupal list && \

--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@
 This is a DDEV addon for doing Drupal core development.
 
 ```
-git clone git@git.drupal.org:project/drupal.git
-cd drupal
-ddev config --auto
-ddev start
-ddev get justafish/ddev-drupal-core-dev
-ddev restart
-ddev composer install
+git clone git@git.drupal.org:project/drupal.git && \
+cd drupal && \
+ddev config --auto && \
+ddev start && \
+ddev get justafish/ddev-drupal-core-dev && \
+ddev restart && \
+ddev composer install && \
 
 # See included commands
-ddev drupal list
+ddev drupal list && \
 
 # Install drupal
-ddev drupal install
+ddev drupal install && \
 
 # Run PHPUnit tests
-ddev phpunit core/modules/sdc
+ddev phpunit core/modules/sdc && \
 
 # Run Nightwatch tests (currently only runs on Chrome)
 ddev nightwatch --tag core

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ddev composer install
 ddev drupal list
 
 # Install drupal
-ddev drupal install && \
+ddev drupal install
 
 # Run PHPUnit tests
 ddev phpunit core/modules/sdc

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ddev drupal list
 ddev drupal install && \
 
 # Run PHPUnit tests
-ddev phpunit core/modules/sdc && \
+ddev phpunit core/modules/sdc
 
 # Run Nightwatch tests (currently only runs on Chrome)
 ddev nightwatch --tag core


### PR DESCRIPTION
There's all sorts of reasons a line could fail here, from network issues to host issues. Let's stop processing if something errors out.