### PR TITLE
Improve initial instructions to use current clone etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 This is a DDEV addon for doing Drupal core development.
 
 ```
-git clone git@git.drupal.org:project/drupal.git && \
-cd drupal && \
-ddev config --auto && \
-ddev start && \
-ddev get justafish/ddev-drupal-core-dev && \
-ddev restart && \
+git clone https://git.drupalcode.org/project/drupal.git core-dev
+cd core-dev
+ddev config --project-type=drupal10
+ddev start
+ddev get justafish/ddev-drupal-core-dev
+ddev restart
 ddev composer install
 
 # See included commands


### PR DESCRIPTION
We did a LONG support help in #ddev Slack with quite a number of stumbles on this.

* Use current git clone technique (it may need --branch as well)
* Use a directory name and project name that is more suited, like `core-dev`
* Current stable DDEV does not detect drupal11 (which is HEAD) so `ddev config --auto` gets the `php` project type.
* Don't use `&&` for setup because people won't pay attention to failures.

Obviously the `--project-type=drupal10` will want to be updated when DDEV has support for drupal11 later this year. It will probably be `--project-type=drupal` then.