### PR TITLE
A few more improvements to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ddev drupal install
 ````
 > :warning: To avoid unstaged conflicts in git, **do not** `ddev composer require drush/drush`.  A subset of that kind of functionality is available with `ddev drupal list`.
 
-In case you need to drop your database tables because you are for example working in the context of the Drupal installer you can simply manually delete the SQLite database file located in `sites/default/files/.sqlite`.
+To drop your database tables, for example if you're working in the context of the Drupal installer, manually delete the SQLite database file located in `sites/default/files/.sqlite`.
 
 
 ## PHPUnit

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Next install a demo site, which is not intended for production:
 ````
 ddev drupal install
 ````
-> :warning: There is no need to `composer require drush/drush` to get the ability to for example clear caches. A subset of that kind of functionality is available with `ddev drupal list`. Otherwise you won't be able to checkout any added feature branch due to unstaged changes for commit.
+> :warning: There is no need to `ddev composer require drush/drush` to get the ability to for example clear caches. A subset of that kind of functionality is available with `ddev drupal list`. Otherwise you won't be able to checkout any added feature branch due to unstaged changes for commit.
 
 In case you need to drop your database tables because you are for example working in the context of the Drupal installer you can simply manually delete the SQLite database file located in `sites/default/files/.sqlite`.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Next install a demo site, which is not intended for production:
 ````
 ddev drupal install
 ````
-> :warning: There is no need to `ddev composer require drush/drush` to get the ability to for example clear caches. A subset of that kind of functionality is available with `ddev drupal list`. Otherwise you won't be able to checkout any added feature branch due to unstaged changes for commit.
+> :warning: To avoid unstaged conflicts in git, **do not** `ddev composer require drush/drush`.  A subset of that kind of functionality is available with `ddev drupal list`.
 
 In case you need to drop your database tables because you are for example working in the context of the Drupal installer you can simply manually delete the SQLite database file located in `sites/default/files/.sqlite`.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * [What is ddev-drupal-core-dev?](#what-is-ddev-drupal-core-dev)
 * [Initial Setup](#initial-setup)
 * [Install Drupal](#install-drupal)
-* [PHP Unit](#php-unit)
+* [PHPUnit](#phpunit)
 * [Nighwatch](#nightwatch)
 
 ## What is ddev-drupal-core-dev?

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ddev phpunit core/modules/sdc
 
 You can watch Nightwatch running in real time at https://drupal.ddev.site:7900
 for Chrome and https://drupal.ddev.site:7901 for Firefox. The password is
-"secret". YMMV using Firefox as core tests don't currently run on it.(currently only runs on Chrome)
+"secret". (Core tests using Firefox are not yet mature.)
 
 Only core tests
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ddev-drupal-core-dev
 
-* [What is ddev-drupal-core-dev](#what-is-ddev-drupal-core-dev)
+* [What is ddev-drupal-core-dev?](#what-is-ddev-drupal-core-dev)
 * [Initial Setup](#initial-setup)
 * [Install Drupal](#install-drupal)
-* [PHP Unit](#install-drupal)
-* [Nighwatch](#install-drupal)
+* [PHP Unit](#php-unit)
+* [Nighwatch](#nightwatch)
 
-## What is `ddev-drupal-core-dev`
-This is a DDEV-addon for doing Drupal Core development.
+## What is ddev-drupal-core-dev?
+This is a [DDEV](https://github.com/ddev/ddev) add-on for doing Drupal Core development.
 
 
 ## Initial Setup

--- a/README.md
+++ b/README.md
@@ -1,37 +1,62 @@
-# ddev-core-dev
+# ddev-drupal-core-dev
 
-This is a DDEV addon for doing Drupal core development.
+* [What is ddev-drupal-core-dev](#what-is-ddev-drupal-core-dev)
+* [Initial Setup](#initial-setup)
+* [Install Drupal](#install-drupal)
+* [PHP Unit](#install-drupal)
+* [Nighwatch](#install-drupal)
+
+## What is `ddev-drupal-core-dev`
+This is a DDEV-addon for doing Drupal Core development.
+
+
+## Initial Setup
 
 We're in #ddev-for-core-dev on [Drupal Slack](https://www.drupal.org/community/contributor-guide/reference-information/talk/tools/slack) (but please try and keep work and feature requests in Issues where it's visible to all 🙏)
 
 ```
 git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
-ddev config --project-type=drupal10
+ddev config --project-type=drupal10 --omit-containers=db
 ddev start
 ddev corepack enable
 ddev get justafish/ddev-drupal-core-dev
 ddev restart
 ddev composer install
+````
+Because `ddev-drupal-core-dev` is using SQLite the database container could be omitted on `ddev config --project-type=drupal10 --omit-containers=db`.
 
-# See included commands
+
+## Install Drupal
+
+To get an overview of the list of available tasks:
+
+```
 ddev drupal list
+````
 
-# Install drupal
+Next install a demo site, which is not intended for production:
+
+````
 ddev drupal install
+````
+> :warning: There is no need to `composer require drush/drush` to get the ability to for example clear caches. A subset of that kind of functionality is available with `ddev drupal list`. Otherwise you won't be able to checkout any added feature branch due to unstaged changes for commit.
 
-# Run PHPUnit tests
+In case you need to drop your database tables because you are for example working in the context of the Drupal installer you can simply manually delete the SQLite database file located in `sites/default/files/.sqlite`.
+
+
+## PHPUnit
+
+```
 ddev phpunit core/modules/sdc
-
-# Run Nightwatch tests (currently only runs on Chrome)
-ddev nightwatch --tag core
 ```
 
-## Nightwatch Examples
+
+## Nightwatch
 
 You can watch Nightwatch running in real time at https://drupal.ddev.site:7900
 for Chrome and https://drupal.ddev.site:7901 for Firefox. The password is
-"secret". YMMV using Firefox as core tests don't currently run on it.
+"secret". YMMV using Firefox as core tests don't currently run on it.(currently only runs on Chrome)
 
 Only core tests
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ We're in #ddev-for-core-dev on [Drupal Slack](https://www.drupal.org/community/c
 ```
 git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
+# Because `ddev-drupal-core-dev` is using SQLite the database
+# container is omitted by the `--omit-containers=db` flag
 ddev config --omit-containers=db --disable-settings-management
 ddev start
 ddev corepack enable
@@ -24,8 +26,6 @@ ddev get justafish/ddev-drupal-core-dev
 ddev restart
 ddev composer install
 ````
-Because `ddev-drupal-core-dev` is using SQLite the database container could be omitted on `ddev config --project-type=drupal10 --omit-containers=db`.
-
 
 ## Install Drupal
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ddev drupal install
 ````
 > :warning: To avoid unstaged conflicts in git, **do not** `ddev composer require drush/drush`.  A subset of that kind of functionality is available with `ddev drupal list`.
 
-To drop your database tables, for example if you're working in the context of the Drupal installer, manually delete the SQLite database file located in `sites/default/files/.sqlite`.
+To drop your database tables, for example if you're working in the context of the Drupal installer, simply run `ddev drupal uninstall`. That deletes the `settings.php` file and the `/sites/default/files` folder including the SQLite database file.
 
 
 ## PHPUnit

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To drop your database tables, for example if you're working in the context of th
 ## PHPUnit
 
 ```
-ddev phpunit core/modules/sdc
+ddev phpunit core/modules/workspaces
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We're in #ddev-for-core-dev on [Drupal Slack](https://www.drupal.org/community/c
 ```
 git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
-ddev config --project-type=drupal10 --omit-containers=db
+ddev config --omit-containers=db --disable-settings-management
 ddev start
 ddev corepack enable
 ddev get justafish/ddev-drupal-core-dev


### PR DESCRIPTION
I've already created a draft before (https://github.com/justafish/ddev-drupal-core-dev/pull/9) but thanks to my "excellent" git and github skills something went wrong when i tried to sync my branch with the latest changes when randys PR went in. I've simply created a new PR now, that was faster incorporating my suggested changes i've done locally so far. 

and again at first thank you for creating that excellent add-on! and as a disclaimer i am not a developer just a regular ddev user who was just used to a composer patches based workflow for testing issues on drupal.org. when i first tried the add-on i ran into a few stepping blocks since it is following a slightly different paradigm (i've expecting the folder structure with web as the docroot and i've installed drush wondering why i haven't had a `git status` without any changes). one or two weeks ago i've also noticed a support request on the drupal slack by someone trying to get the add-on work (who had basically the same issues like me). so based on my own experience as well as the details i've learned during the conversation on slack i've tried to come up with a few improvements to the README.md: 

- added a TOC and structured the entire document with headlines
- untwine the long codeblock at the beginning and move the different parts into the appropriate sections
- tried to make it clear nothing should be installed (required) with composer like for example drush (therefore the warning box to make it extra clear)
- added the omit the database container flag since the addon is using SQLite (to save a few megabyte but at the same time to help the user to understand how the add is working and what database is used - which is also relevant in case someone wants to drop the database tables in case one is working on a patch in the context of the drupal installer).  
 
plus i've added the suggestions @rfay made over on the old PR into this one