### PR TITLE
⏫ bump github-action-add-on-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:
 
 # This is required for "gautamkrishnar/keepalive-workflow"
 permissions:
-  contents: write
+  actions: write
 
 jobs:
   tests:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup SSH
         run: ssh-keyscan -t rsa git.drupal.org >> ~/.ssh/known_hosts
 
-      - uses: ddev/github-action-add-on-test@v1
+      - uses: ddev/github-action-add-on-test@v2
         with:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR bumps the github-action-add-on-test workflow.
The prevents the dummy commits, made by the keep-alive workflow to prevent automated testing from being disabled.

@see https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0