### PR TITLE
Handle new yarn 4 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a DDEV addon for doing Drupal core development.
 git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
 ddev config --project-type=drupal10
-ddev start
+ddev start && ddev corepack enable
 ddev get justafish/ddev-drupal-core-dev
 ddev restart
 ddev composer install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is a DDEV addon for doing Drupal core development.
 git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
 ddev config --project-type=drupal10
-ddev start && ddev corepack enable
+ddev start
+ddev corepack enable
 ddev get justafish/ddev-drupal-core-dev
 ddev restart
 ddev composer install

--- a/install.yaml
+++ b/install.yaml
@@ -26,7 +26,6 @@ post_install_actions:
   - cp core-dev/gitignore ../.gitignore
   - mkdir -p ../test_output
   - chmod +w ../test_output
-  - if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then ddev start; fi
   - ddev exec corepack enable
   - cd ../core && ddev yarn
 

--- a/install.yaml
+++ b/install.yaml
@@ -26,7 +26,7 @@ post_install_actions:
   - cp core-dev/gitignore ../.gitignore
   - mkdir -p ../test_output
   - chmod +w ../test_output
-  - cd ../ && ddev exec yarn --cwd="core"
+  - cd ../core && ddev yarn
 
 removal_actions:
   - rm core/phpunit.xml

--- a/install.yaml
+++ b/install.yaml
@@ -26,6 +26,8 @@ post_install_actions:
   - cp core-dev/gitignore ../.gitignore
   - mkdir -p ../test_output
   - chmod +w ../test_output
+  - if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then ddev start; fi
+  - ddev exec corepack enable
   - cd ../core && ddev yarn
 
 removal_actions:

--- a/web-build/Dockerfile
+++ b/web-build/Dockerfile
@@ -1,6 +1,5 @@
 #ddev-generated
 # Note that the chromium-driver install could be moved to webimage_extra_packages
 RUN sudo apt-get update && sudo apt-get install chromium-driver -y
-# Depending on the outcome of https://github.com/ddev/ddev/pull/5988
-# this may not be necessary in DDEV v1.23+
+# This will not be necessary in DDEV v1.23+
 RUN corepack enable

--- a/web-build/Dockerfile
+++ b/web-build/Dockerfile
@@ -1,2 +1,6 @@
 #ddev-generated
+# Note that the chromium-driver install could be moved to webimage_extra_packages
 RUN sudo apt-get update && sudo apt-get install chromium-driver -y
+# Depending on the outcome of https://github.com/ddev/ddev/pull/5988
+# this may not be necessary in DDEV v1.23+
+RUN corepack enable


### PR DESCRIPTION
There are a couple of problems with the new yarn v4 requirements for core. 

This PR
* enables corepack
* Used `ddev yarn` in the `core` directory, which seems to work whereas the `ddev exec yarn --cwd` does not, which I assume is a bug in yarn/node

Test with
```
ddev get https://github.com/rfay/ddev-drupal-core-dev/tarball/20240324_yarn_problems
```