### PR TITLE
[SNAPSHOT, PAUSED] Captured bug fixes that are mostly fixed elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
 ddev config --project-type=drupal10
 ddev start
-ddev corepack enable
+ddev exec corepack enable
 ddev get justafish/ddev-drupal-core-dev
 ddev restart
 ddev composer install
@@ -16,13 +16,10 @@ ddev composer install
 ddev drupal list
 
 # Install drupal
-ddev drupal install
+ddev reset && ddev drupal install
 
-# Run PHPUnit tests
-ddev phpunit core/modules/sdc
-
-# Run Nightwatch tests (currently only runs on Chrome)
-ddev nightwatch --tag core
+# Verify some sample tests that require a working site
+ddev phpunit core/tests/Drupal/FunctionalTests/Core
 ```
 
 ## Nightwatch Examples

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ ddev reset && ddev drupal install
 
 # Verify some sample tests that require a working site
 ddev phpunit core/tests/Drupal/FunctionalTests/Core
+
+# Verify you can run Nightwatch tests
+ddev nightwatch --tag ajax
 ```
 
 ## Nightwatch Examples

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ ddev drupal list
 # Install drupal
 ddev reset && ddev drupal install
 
-# Verify some sample tests that require a working site
+# Verify some sample PHPUnit tests that require a working site
 ddev phpunit core/tests/Drupal/FunctionalTests/Core
 
-# Verify you can run Nightwatch tests
+# Verify some sample Nightwatch tests
 ddev nightwatch --tag ajax
 ```
 

--- a/commands/web/reset
+++ b/commands/web/reset
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Required because if sites/default/files is created (by volume mounting perhaps)
+# then `ddev drupal install` fails.`
+
+## Description: Reset Drupal ready to install.
+## Usage: reset
+## Example: "ddev reset"
+
+chmod 775 sites/default sites/default/settings.php
+rm -rf sites/default/files
+rm -f sites/default/settings.php

--- a/install.yaml
+++ b/install.yaml
@@ -7,6 +7,7 @@ project_files:
   - docker-compose.core-dev-selenium.yaml
   - core-dev/phpunit-firefox.xml
   - core-dev/phpunit-chrome.xml
+  - commands/web/reset
   - commands/web/drupal
   - commands/web/phpunit
   - commands/web/nightwatch
@@ -26,7 +27,8 @@ post_install_actions:
   - cp core-dev/gitignore ../.gitignore
   - mkdir -p ../test_output
   - chmod +w ../test_output
-  - ddev exec corepack enable
+  - ddev exec corepack enable # @todo remove when in DDEV core.
+  - ddev exec yarn set version stable
   - cd ../core && ddev yarn
 
 removal_actions:


### PR DESCRIPTION
I'm not fully across either ddev or yarn, so I'm hacking a bit but at least this captures my experience. Note that I'm using the DDEV alpha released today.

```
ddev version v1.23.0-alpha1
Docker version 25.0.5, build 5dc9bcc (Rancher Desktop)
```

* `ddev corepack enable` fails, should be `ddev exec corepack enable` ?
* Yarn seems to need the `ddev exec yarn set version stable` which (after `corepack enable`) means it can then successfully install v4.
* DDEV seems intent on creating a `sites/default/files` (is this due to docker-compose mounting?) and this breaks the `ddev drupal install` command, so i added a `ddev reset` command.
* Replaced the two sample tests with quicker more stable examples

TO TEST

Follow the same instructions except `ddev get` from my fork

```
ddev get simesy/ddev-drupal-core-dev
```
