### PR TITLE
Prepare for DDEV 1.23 and improve initial config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ We're in #ddev-for-core-dev on [Drupal Slack](https://www.drupal.org/community/c
 ```
 git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
-ddev config --project-type=drupal10
+ddev config --omit-containers=db --disable-settings-management
 ddev start
-ddev corepack enable
 ddev get justafish/ddev-drupal-core-dev
 ddev restart
 ddev composer install

--- a/config.ddev-drupal-core-dev.yaml
+++ b/config.ddev-drupal-core-dev.yaml
@@ -1,0 +1,10 @@
+# #ddev-generated
+# This file is placed by the justafish/ddev-drupal-core-dev addon.
+
+webimage_extra_packages: ["chromium-driver"]
+ddev_version_constraint: '>=v1.23.0'
+upload_dirs:
+# The install technique tries to remove all of sites/default/files
+# but with DDEV + mutagen that isn't possible.
+# so just redirect the upload_dirs.
+    - .ddev/tmp

--- a/core-dev/phpunit-chrome.xml
+++ b/core-dev/phpunit-chrome.xml
@@ -23,7 +23,8 @@
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <env name="SIMPLETEST_BASE_URL" value="DRUPAL_CORE_DDEV_URL"/>
-        <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
+        <!-- <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/> -->
+        <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/db.sqlite"/>        
         <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/www/html/test_output"/>
         <!-- By default, browser tests will output links that use the base URL set
          in SIMPLETEST_BASE_URL. However, if your SIMPLETEST_BASE_URL is an internal

--- a/core-dev/phpunit-firefox.xml
+++ b/core-dev/phpunit-firefox.xml
@@ -23,7 +23,8 @@
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <env name="SIMPLETEST_BASE_URL" value="DRUPAL_CORE_DDEV_URL"/>
-        <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
+        <!-- <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/> -->
+        <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/db.sqlite"/>
         <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/www/html/test_output"/>
         <!-- By default, browser tests will output links that use the base URL set
          in SIMPLETEST_BASE_URL. However, if your SIMPLETEST_BASE_URL is an internal

--- a/install.yaml
+++ b/install.yaml
@@ -3,7 +3,8 @@
 name: ddev-drupal-core-dev
 
 project_files:
-  - web-build/Dockerfile
+  - config.ddev-drupal-core-dev.yaml
+  - web-build/Dockerfile.ddev-drupal-core-dev
   - docker-compose.core-dev-selenium.yaml
   - core-dev/phpunit-firefox.xml
   - core-dev/phpunit-chrome.xml
@@ -26,7 +27,6 @@ post_install_actions:
   - cp core-dev/gitignore ../.gitignore
   - mkdir -p ../test_output
   - chmod +w ../test_output
-  - ddev exec corepack enable
   - cd ../core && ddev yarn
 
 removal_actions:

--- a/web-build/Dockerfile.ddev-drupal-core-dev
+++ b/web-build/Dockerfile.ddev-drupal-core-dev
@@ -1,14 +1,8 @@
 #ddev-generated
-# Note that the chromium-driver install could be moved to webimage_extra_packages
-RUN sudo apt-get update && sudo apt-get install chromium-driver -y
-# This will not be necessary in DDEV v1.23+
-RUN corepack enable
 
-# TODO:
-# This section is temporary and needs to be removed when
-# https://github.com/justafish/ddev-drupal-core-dev/pull/23/files#top
-# is pulled, because it includes this update.
 ARG TARGETPLATFORM
+
+# Drupal core needs later Sqlite than Debian 12 so install from Debian Trixie.
 RUN SQLITE_VERSION=3.45.1 && \
     mkdir -p /tmp/sqlite3 && \
     wget -O /tmp/sqlite3/sqlite3.deb https://ftp.debian.org/debian/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \


### PR DESCRIPTION
This PR prepares the plugin for ddev 1.23 and also is a little more explicit about its config including setting some initial config to make sure ddev inits correctly.

**Please note** that if you want to **reinstall Drupal.** there is a known issue with the sites/default being hardened and it's not obvious the user how to reset drupal. A future PR will fix this.

@rpkoller has more extensive testing and he should weigh in on the PR to make sure he's happy.

Anyone testing should note to vary the README by cloning my fork inside the drupal repo, and then doing `ddev get ddev-drupal-core-dev` to use the clone as the plugin source.

Tested against 1.22.7 and 1.23-beta1

1. Clone drupal, `cd drupal`
2. `git clone git@github.com:simesy/ddev-drupal-core-dev.git` (should be main branch)
3. `ddev config --omit-containers=db --disable-settings-management`
4. `ddev start`
5. `ddev get ddev-drupal-core-dev`
6. `ddev restart`
7. `ddev composer install`

