### PR TITLE
fix: make removal smoother and successful

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -30,7 +30,10 @@ post_install_actions:
   - cd ../core && ddev yarn
 
 removal_actions:
-  - rm core/phpunit.xml
-  - rm -rf test_output
-  - rm core/.env
-  - rm .gitignore
+  - |
+    for item in ../core/phpunit.xml ../core/.env ../.gitignore; do 
+      if grep '#ddev-generated' ${item} >/dev/null; then
+        rm -f ${item}
+      fi
+    done
+  - rm -rf ../test_output


### PR DESCRIPTION
I happened to note that `ddev get --remove ddev-drupal-core-dev` wasn't working quite right for a couple reasons.

This cleans up removal and makes sure that altered files don't get removed.