### PR TITLE
fix: tests were using mysql instead of sqlite

### DIFF
--- a/core-dev/phpunit-chrome.xml
+++ b/core-dev/phpunit-chrome.xml
@@ -23,7 +23,7 @@
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <env name="SIMPLETEST_BASE_URL" value="DRUPAL_CORE_DDEV_URL"/>
-        <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
+        <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/db.sqlite"/>
         <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/www/html/test_output"/>
         <!-- By default, browser tests will output links that use the base URL set
          in SIMPLETEST_BASE_URL. However, if your SIMPLETEST_BASE_URL is an internal

--- a/core-dev/phpunit-firefox.xml
+++ b/core-dev/phpunit-firefox.xml
@@ -23,7 +23,7 @@
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <env name="SIMPLETEST_BASE_URL" value="DRUPAL_CORE_DDEV_URL"/>
-        <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
+        <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/db.sqlite"/>
         <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/www/html/test_output"/>
         <!-- By default, browser tests will output links that use the base URL set
          in SIMPLETEST_BASE_URL. However, if your SIMPLETEST_BASE_URL is an internal


### PR DESCRIPTION
This add-on is very opinionated about using sqlite.

However, I happened to notice a gazillion tables being created in the mariadb database... because the tests were using the mysql URL.

This PR changes the SIMPLETEST_DB in the two phpunit.xml files so it uses the sqlite db.

Without this, nearly no tests can run successfully as in current proposed `omit_containers[db]`