### PR TITLE
fix: Install drush without affecting git index

### DIFF
--- a/commands/web/drush
+++ b/commands/web/drush
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#ddev-generated
+## Description: Run drush CLI inside the web container, installing it if necessary
+## Usage: drush [flags] [args]
+## Example: "ddev drush uli" or "ddev drush sql-cli" or "ddev drush --version"
+## ProjectTypes: drupal7,drupal8,drupal9,drupal10,drupal,backdrop
+## ExecRaw: true
+
+if ! command -v drush >/dev/null; then
+  echo "drush is not yet installed. Installing it...'"
+  .ddev/core-dev/install_drush.sh
+fi
+drush "$@"

--- a/config.ddev-drupal-core-dev.yaml
+++ b/config.ddev-drupal-core-dev.yaml
@@ -3,7 +3,6 @@
 
 webimage_extra_packages: ["chromium-driver"]
 ddev_version_constraint: '>=v1.23.1'
-omit_containers: ["db"]
 upload_dirs:
 # The install technique tries to remove all of sites/default/files
 # but with DDEV + mutagen that isn't possible.

--- a/core-dev/gitignore
+++ b/core-dev/gitignore
@@ -7,3 +7,4 @@
 /sites/default/files
 /vendor
 test_output
+*.orig

--- a/core-dev/install_drush.sh
+++ b/core-dev/install_drush.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#ddev-generated
+# This script installs drush/drush without changing the git
+# status of the Drupal checkout
+
+set -eu -o pipefail
+
+if command -v drush >/dev/null; then
+  echo "drush is already installed, taking no action. You can remove it if you want to reinstall"
+  exit
+fi
+
+echo "Installing drush without affecting git status"
+
+# Make certain that we have something staged so we can create stash
+touch .makedrush.txt
+git add .makedrush.txt
+
+# Save the stash, which will include anything people were doing
+# plus the .makedrush.txt. This gets us back to "no changes"
+# in `git status`
+git stash
+
+# Install drush
+composer require drush/drush
+
+# Roll back to what we started with. Cleans up
+# composer.* and anything else that the drush install changes
+# But vendor directory is untouched since
+# it's gitignored
+git reset --hard
+
+# Restore anything that might have been staged
+# prior to the start
+git stash apply
+
+# Get rid of our dummy file
+git rm -f .makedrush.txt
+
+echo "drush/drush is installed in $(which drush)"

--- a/core-dev/install_drush.sh
+++ b/core-dev/install_drush.sh
@@ -23,7 +23,7 @@ git add .makedrush.txt
 git stash
 
 # Install drush
-composer require drush/drush
+composer require drush/drush --with-dependencies
 
 # Roll back to what we started with. Cleans up
 # composer.* and anything else that the drush install changes
@@ -33,7 +33,7 @@ git reset --hard
 
 # Restore anything that might have been staged
 # prior to the start
-git stash apply
+git stash pop
 
 # Get rid of our dummy file
 git rm -f .makedrush.txt

--- a/install.yaml
+++ b/install.yaml
@@ -8,8 +8,10 @@ project_files:
   - core-dev/phpunit-firefox.xml
   - core-dev/phpunit-chrome.xml
   - commands/web/drupal
+  - commands/web/drush
   - commands/web/phpunit
   - commands/web/nightwatch
+  - core-dev/install_drush.sh
   - core-dev/gitignore
   - core-dev/.env
   - core-dev/src/Command/AdminLoginCommand.php

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -2,22 +2,36 @@ setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export TESTDIR=~/tmp/test-ddev-drupal-core-dev
-  mkdir -p $TESTDIR
-  export PROJNAME=ddev-drupal-core-dev
+  rm -rf ${TESTDIR}
+  mkdir -p ${TESTDIR}
+  export PROJNAME=test-ddev-drupal-core-dev
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   curl -L -o /tmp/drupal.tar.gz https://ftp.drupal.org/files/projects/drupal-11.x-dev.tar.gz
   tar --strip-components 1 -zxf /tmp/drupal.tar.gz -C ${TESTDIR}
   cd "${TESTDIR}"
+  mv vendor /tmp/vendor.bak
+  git init && git add . >/dev/null && git commit -m "current" >/dev/null
+  mv /tmp/vendor.bak vendor
   ddev config --project-name=${PROJNAME} --upload-dirs=.ddev/tmp
   ddev config --update
   ddev start -y >/dev/null
+  ddev composer install >/dev/null
 }
 
-health_checks() {
-  ddev exec "curl -s chrome:7900" | grep "noVNC"
-  ddev exec "curl -s firefox:7901" | grep "noVNC"
+base_checks() {
+  ddev exec "curl -s chrome:7900" | grep "noVNC" >/dev/null
+  ddev exec "curl -s firefox:7901" | grep "noVNC" >/dev/null
   ddev phpunit core/tests/Drupal/Tests/Component/Datetime/DateTimePlusTest.php
+}
+
+drush_checks() {
+  # Make sure there's nothing in the git index before drush install
+  git diff --cached --quiet
+  ddev drush st
+  # Make sure there's nothing after the drush install
+  git diff --cached --quiet || (echo "git index has been touched" && exit 2)
+  ddev drush si -y --account-pass=admin
 }
 
 teardown() {
@@ -33,7 +47,8 @@ teardown() {
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
   ddev restart
-  health_checks
+  base_checks
+  drush_checks
 }
 
 #TODO: Re-enable release tests after the add-on has a release with DDEV v1.23.0 support

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -11,6 +11,8 @@ setup() {
   tar --strip-components 1 -zxf /tmp/drupal.tar.gz -C ${TESTDIR}
   cd "${TESTDIR}"
   mv vendor /tmp/vendor.bak
+  git config --global user.email "example@example.com"
+  git config --global user.name "Example Example"
   git init && git add . >/dev/null && git commit -m "current" >/dev/null
   mv /tmp/vendor.bak vendor
   ddev config --project-name=${PROJNAME} --upload-dirs=.ddev/tmp


### PR DESCRIPTION
This PR installs drush (on demand) so it can be widely used. This is also a first step toward being able to install database types other than sqlite3

* Script install_drush.sh saves away current git index state, installs drush, then rolls back to original image state
* Custom "drush" command checks to see if drush is available, and if not, runs install_drush.sh


## Testing:

Test with
```
ddev get https://github.com/rfay/ddev-drupal-core-dev/tarball/20240501_drush
```

- [ ] Start a project
- [ ] Use `ddev drush st` to see it get installed
- [ ] Then `ddev drush sql-cli` and `ddev drush si -y demo_umami --account-pass=admin`
- [ ] `git status` should show no changes of any kind.

## Automated tests

Coming