### PR TITLE
fix: upstream changes break chromium-driver installation "PermissionError: [Errno 13] Permission denied: '/var/log/supervisord.log'"

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -18,6 +18,7 @@ project_files:
   - core-dev/src/Command/TestCommand.php
   - core-dev/src/Command/TestBrowserCommand.php
   - core-dev/src/Command/UninstallCommand.php
+  - web-build/Dockerfile.drupal-core-dev
 
 post_install_actions:
   - cp core-dev/phpunit-chrome.xml ../core/phpunit.xml

--- a/web-build/Dockerfile.drupal-core-dev
+++ b/web-build/Dockerfile.drupal-core-dev
@@ -1,0 +1,5 @@
+# This is required because of upstream changes related to
+# `webimage_extra_packages: ["chromium-driver"]``
+# These problems will be solved in DDEV v1.23.3.
+# See https://github.com/ddev/ddev/pull/6363
+RUN chmod 777 /run/php /var/log


### PR DESCRIPTION
Upstream changes to Debian and chromium-driver result in failure to start currently:

These problems will be solved in DDEV v1.23.3, and this can then be reverted then.

See 
* https://github.com/ddev/ddev/pull/6363

The failure looks like this in `ddev logs`, especially "PermissionError: [Errno 13] Permission denied: '/var/log/supervisord.log'":

```
+ exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord-nginx-fpm.conf
Traceback (most recent call last):
  File "/usr/bin/supervisord", line 33, in <module>
    sys.exit(load_entry_point('supervisor==4.2.5', 'console_scripts', 'supervisord')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/supervisor/supervisord.py", line 359, in main
    go(options)
  File "/usr/lib/python3/dist-packages/supervisor/supervisord.py", line 369, in go
    d.main()
  File "/usr/lib/python3/dist-packages/supervisor/supervisord.py", line 72, in main
    self.options.make_logger()
  File "/usr/lib/python3/dist-packages/supervisor/options.py", line 1488, in make_logger
    loggers.handle_file(
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 419, in handle_file
    handler = RotatingFileHandler(filename, 'a', maxbytes, backups)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 213, in __init__
    FileHandler.__init__(self, filename, mode)
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 160, in __init__
    self.stream = open(filename, mode)
                  ^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/var/log/supervisord.log'
+ trap - SIGTERM
+ kill -- -1
```