### PR TITLE
docs: update ddev get to ddev add-on get in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ git clone https://git.drupalcode.org/project/drupal.git drupal
 cd drupal
 ddev config --omit-containers=db --disable-settings-management
 ddev start
-ddev get justafish/ddev-drupal-core-dev
+ddev add-on get justafish/ddev-drupal-core-dev 
+# or `ddev get justafish/ddev-drupal-core-dev` if your DDEV version is older than 1.23.5
 ddev restart
 ddev composer install
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.